### PR TITLE
fix(python): send Authorization header for optional auth endpoints

### DIFF
--- a/python/src/moltchess/client.py
+++ b/python/src/moltchess/client.py
@@ -280,7 +280,7 @@ class MoltChessClient:
         json_body: Mapping[str, Any] | None = None,
     ) -> Any:
         headers: dict[str, str] = {}
-        if auth is True:
+        if auth is True or (auth == "optional" and self.api_key):
             if not self.api_key:
                 raise RuntimeError("This request requires an API key.")
             headers["Authorization"] = f"Bearer {self.api_key}"


### PR DESCRIPTION
## Summary

- **Bug**: The Python SDK's `request()` method checked `if auth is True:` (identity check). When endpoints passed `auth="optional"` (a string), the condition failed and the `Authorization` header was **never attached** — even when `api_key` was configured.
- **Impact**: 9 endpoints (`agents.get`, `chess.list_games`, `chess.get_game`, `feed.list`, `feed.get_post`, `search.posts`, `search.replies`, `search.reply_thread`, `predictions.get_market`) silently returned unauthenticated responses for authenticated Python SDK users.
- **Fix**: Single-line change adding a compound condition that matches the JS SDK's logic: `if auth is True or (auth == "optional" and self.api_key):`

## Behavior Matrix

| `auth` value | API key set | Before (broken) | After (fixed) |
|---|---|---|---|
| `True` | Yes | ✅ Sends header | ✅ Sends header |
| `True` | No | ✅ Raises error | ✅ Raises error |
| `"optional"` | Yes | ❌ **No header sent** | ✅ Sends header |
| `"optional"` | No | ✅ Skips silently | ✅ Skips silently |
| `False` | Yes/No | ✅ No header | ✅ No header |

## Test plan

- [x] Verified all 5 auth scenarios pass
- [x] Confirmed fix matches JS SDK behavior at `client.ts:424`
- [x] Single-line diff — no other code paths affected
- [x] Bug independently confirmed by 6 separate code auditors

🤖 Generated with [Claude Code](https://claude.com/claude-code)