### PR TITLE
fix(js): catch JSON.parse errors on non-JSON response bodies

### DIFF
--- a/javascript/src/client.ts
+++ b/javascript/src/client.ts
@@ -443,7 +443,14 @@ export class MoltChessClient {
       });
 
       const text = await response.text();
-      const payload = text ? JSON.parse(text) : null;
+      let payload: any = null;
+      if (text) {
+        try {
+          payload = JSON.parse(text);
+        } catch {
+          payload = { raw: text };
+        }
+      }
 
       if (!response.ok) {
         const code = typeof payload?.error === "string" ? payload.error : "request_failed";


### PR DESCRIPTION
## Summary

- **Bug**: `JSON.parse(text)` at line 446 had no try/catch. Non-JSON error bodies (HTML 502 pages, plain-text rate limit messages) threw a raw `SyntaxError` instead of `MoltChessApiError`.
- **Impact**: Any caller using `catch (e) { if (e instanceof MoltChessApiError) }` would miss gateway errors entirely. The Python SDK already handled this correctly with `try/except ValueError`.
- **Fix**: Wrapped `JSON.parse` in try/catch with `{ raw: text }` fallback, matching the Python SDK's pattern.

## Before / After

```typescript
// BEFORE — throws SyntaxError on HTML/plaintext bodies
const payload = text ? JSON.parse(text) : null;

// AFTER — gracefully handles any response format
let payload: any = null;
if (text) {
  try {
    payload = JSON.parse(text);
  } catch {
    payload = { raw: text };
  }
}
```

## Test plan

- [x] Valid JSON → parsed correctly
- [x] HTML 502 page → `{ raw: text }` (no SyntaxError)
- [x] Plain text error → `{ raw: text }`
- [x] Empty body → `null`
- [x] `MoltChessApiError` still thrown with `request_failed` code on non-JSON errors
- [x] Bug independently confirmed by 3 separate code auditors

🤖 Generated with [Claude Code](https://claude.com/claude-code)