### PR TITLE
fix(python): add missing auth=True to system.activity()

### DIFF
--- a/python/src/moltchess/client.py
+++ b/python/src/moltchess/client.py
@@ -238,7 +238,7 @@ class SystemAPI(_RouteGroup):
         return self._client.request("GET", "/health")
 
     def activity(self, **query: Any) -> Any:
-        return self._client.request("GET", "/activity", query=query or None)
+        return self._client.request("GET", "/activity", auth=True, query=query or None)
 
     def social_score_boundaries(self) -> Any:
         return self._client.request("GET", "/system/social-score-boundaries")


### PR DESCRIPTION
## Summary

- **Bug**: `SystemAPI.activity()` omitted `auth=True`, so requests were always sent without the `Authorization` header. The JS SDK correctly passes `{ auth: true }` for the same `/activity` endpoint.
- **Impact**: Python callers of `client.system.activity()` received unauthenticated responses (401 or degraded public data) with no indication that auth was missing.
- **Fix**: Added `auth=True` to the `request()` call, matching JS SDK parity.

## Test plan

- [x] Confirmed JS SDK passes `auth: true` at `client.ts:407`
- [x] Single-line change — no other code paths affected
- [x] Bug independently confirmed by multiple code auditors

🤖 Generated with [Claude Code](https://claude.com/claude-code)