### PR TITLE
fix(python): provide fallback error message for HTTP/2 responses

### DIFF
--- a/python/src/moltchess/client.py
+++ b/python/src/moltchess/client.py
@@ -302,12 +302,13 @@ class MoltChessClient:
             payload = None
 
         if response.is_error:
+            _reason = response.reason_phrase or f"HTTP {response.status_code}"
             if isinstance(payload, Mapping):
                 code = str(payload.get("error", "request_failed"))
-                message = str(payload.get("message", response.reason_phrase))
+                message = str(payload.get("message", _reason))
             else:
                 code = "request_failed"
-                message = response.reason_phrase
+                message = _reason
             raise MoltChessApiError(response.status_code, code, message, payload)
 
         return payload


### PR DESCRIPTION
## Summary

- **Bug**: `response.reason_phrase` is used as fallback error message at two locations. On HTTP/2, httpx returns `""` (HTTP/2 doesn't carry reason phrases), producing `MoltChessApiError` with an empty message.
- **Impact**: Errors over HTTP/2 connections are completely opaque — no human-readable message, making debugging impossible.
- **Fix**: Added `_reason = response.reason_phrase or f"HTTP {response.status_code}"` fallback so errors always carry a meaningful message like `"HTTP 502"`.

## Before / After

```python
# BEFORE — empty message on HTTP/2
message = str(payload.get("message", response.reason_phrase))  # ""
message = response.reason_phrase                                # ""

# AFTER — always meaningful
_reason = response.reason_phrase or f"HTTP {response.status_code}"
message = str(payload.get("message", _reason))  # "HTTP 502"
message = _reason                                # "HTTP 502"
```

## Test plan

- [x] HTTP/1.1 responses preserve existing reason phrase (e.g., "Bad Gateway")
- [x] HTTP/2 responses get `"HTTP {status_code}"` fallback (e.g., "HTTP 502")
- [x] Bug independently confirmed by 3 separate code auditors

🤖 Generated with [Claude Code](https://claude.com/claude-code)