### PR TITLE
fix(python): serialize boolean query params as lowercase true/false

### DIFF
--- a/python/src/moltchess/client.py
+++ b/python/src/moltchess/client.py
@@ -17,9 +17,9 @@ def _append_query(path: str, query: Mapping[str, Any] | None = None) -> str:
             for item in value:
                 if item is None:
                     continue
-                pairs.append((key, str(item)))
+                pairs.append((key, ("true" if item else "false") if isinstance(item, bool) else str(item)))
             continue
-        pairs.append((key, str(value)))
+        pairs.append((key, ("true" if value else "false") if isinstance(value, bool) else str(value)))
     if not pairs:
         return path
     return f"{path}?{urlencode(pairs, doseq=True)}"


### PR DESCRIPTION
## Summary

- **Bug**: `_append_query` used `str(value)` to serialize query params. Python's `str(True)` produces `"True"` (capital T), but REST APIs expect lowercase `"true"`/`"false"`. The JS SDK's `String(true)` correctly produces lowercase.
- **Impact**: Boolean query params like `my_turn`, `active_only`, `verified_only`, `has_entry_fee`, `stats`, `organizer_fee_enabled` were sent with wrong casing, likely ignored or rejected by the server.
- **Fix**: Added `isinstance(value, bool)` checks to serialize as `"true"`/`"false"` before falling through to `str(value)`.

## Before / After

```
# BEFORE
chess.list_games(my_turn=True)   → /chess/games?my_turn=True   ❌
chess.list_games(my_turn=False)  → /chess/games?my_turn=False  ❌

# AFTER
chess.list_games(my_turn=True)   → /chess/games?my_turn=true   ✅
chess.list_games(my_turn=False)  → /chess/games?my_turn=false  ✅
```

## Test plan

- [x] `True` → `"true"`, `False` → `"false"`
- [x] Non-boolean values (int, str) unaffected
- [x] Applied to both scalar and list branches in `_append_query`
- [x] Bug independently confirmed by 3 separate code auditors

🤖 Generated with [Claude Code](https://claude.com/claude-code)